### PR TITLE
Docker compose network mode

### DIFF
--- a/product-service/ProductService/Startup.cs
+++ b/product-service/ProductService/Startup.cs
@@ -13,6 +13,7 @@ namespace ProductService
 {
     public class Startup
     {
+        const string CorsPolicy = "InsuranceSalesPolicy";
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -37,6 +38,15 @@ namespace ProductService
                 {
                     Title = $"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name} API",
                     Version = $"{appVer}"
+                });
+            });
+            services.AddCors(options => 
+            {
+                options.AddPolicy(CorsPolicy, policy => 
+                {
+                    policy.WithOrigins("http://localhost")
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
                 });
             });
         }
@@ -64,6 +74,7 @@ namespace ProductService
             {
                 c.SwaggerEndpoint($"/swagger/{appVer}/swagger.json", $"{this.GetType().Name} API {appVer}");
             });
+            app.UseCors(CorsPolicy);
         }
         
         private void JsonOptions(MvcJsonOptions options)

--- a/scripts/app.yml
+++ b/scripts/app.yml
@@ -7,7 +7,8 @@ services:
       dockerfile: product-service/Dockerfile
     image: dotnet-product-service
     container_name: dotnet-product-service
-    network_mode: host
+    ports:
+      - "8081:5030"
 
   dotnet-pricing-service:
     build: 
@@ -15,7 +16,6 @@ services:
       dockerfile: pricing-service/Dockerfile
     image: dotnet-pricing-service
     container_name: dotnet-pricing-service
-    network_mode: host
 
   dotnet-payment-service:
     build: 
@@ -23,7 +23,6 @@ services:
       dockerfile: payment-service/Dockerfile
     image: dotnet-payment-service
     container_name: dotnet-payment-service
-    network_mode: host
 
   dotnet-policy-service:
     build: 
@@ -31,7 +30,6 @@ services:
       dockerfile: policy-service/Dockerfile
     image: dotnet-policy-service
     container_name: dotnet-policy-service
-    network_mode: host
 
   dotnet-policy-search-service:
     build: 
@@ -39,7 +37,6 @@ services:
       dockerfile: policy-search-service/Dockerfile
     image: dotnet-policy-search-service
     container_name: dotnet-policy-search-service
-    network_mode: host
 
   dotnet-auth-service:
     build: 
@@ -47,7 +44,8 @@ services:
       dockerfile: auth-service/Dockerfile
     image: dotnet-auth-service
     container_name: dotnet-auth-service
-    network_mode: host
+    ports:
+      - "6060:6060"
 
   dotnet-chat-service:
     build: 
@@ -55,7 +53,6 @@ services:
       dockerfile: chat-service/Dockerfile
     image: dotnet-chat-service
     container_name: dotnet-chat-service
-    network_mode: host
 
   dotnet-agent-portal-gateway:
     build: 
@@ -63,10 +60,10 @@ services:
       dockerfile: agent-portal-gateway/Dockerfile
     image: dotnet-agent-portal-gateway
     container_name: dotnet-agent-portal-gateway
-    network_mode: host
 
   dotnet-web-vue:
     build: ../Web
     image: dotnet-web-vue
     container_name: dotnet-web-vue
-    network_mode: host
+    ports: 
+      - "80:80"


### PR DESCRIPTION
Change network mode to bridge to allow host containers on macOS and Windows machines. Currently **host** network mode is only available on Linux hosts.

I add also CORS policy to allow communication on localhost with VUEJS website. 