### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ASCLAB .NET Core PoC - LAB Insurance Sales Portal
 
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/409/microservices-on-net-core-sample/badge)](https://builtwithdot.net/project/409/microservices-on-net-core-sample)
+
 This is an example of a very simplified insurance sales system made in a microservice architecture using:
 
 * .NET 7


### PR DESCRIPTION
Since Microservices on .NET Core is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for Microservices on .NET Core to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)