### PR TITLE
Migrate from .NET 7 to  .NET 8

### DIFF
--- a/AgentPortalApiGateway/AgentPortalApiGateway.csproj
+++ b/AgentPortalApiGateway/AgentPortalApiGateway.csproj
@@ -6,13 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
-        <PackageReference Include="Ocelot" Version="18.0.0" />
-        <PackageReference Include="Ocelot.Cache.CacheManager" Version="18.0.0" />
-        <PackageReference Include="Ocelot.Provider.Eureka" Version="18.0.0" />
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
+        <PackageReference Include="Ocelot" Version="23.3.3" />
+        <PackageReference Include="Ocelot.Cache.CacheManager" Version="23.3.3" />
+        <PackageReference Include="Ocelot.Provider.Eureka" Version="23.3.3" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.7" />
     </ItemGroup>
 
 </Project>

--- a/AgentPortalApiGateway/AgentPortalApiGateway.csproj
+++ b/AgentPortalApiGateway/AgentPortalApiGateway.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <UserSecretsId>4761b4d0-7f3f-4a3a-b774-89de95b85112</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3"/>
-        <PackageReference Include="Ocelot" Version="18.0.0"/>
-        <PackageReference Include="Ocelot.Cache.CacheManager" Version="18.0.0"/>
-        <PackageReference Include="Ocelot.Provider.Eureka" Version="18.0.0"/>
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3"/>
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="Ocelot" Version="18.0.0" />
+        <PackageReference Include="Ocelot.Cache.CacheManager" Version="18.0.0" />
+        <PackageReference Include="Ocelot.Provider.Eureka" Version="18.0.0" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
     </ItemGroup>
 
 </Project>

--- a/AgentPortalApiGateway/Dockerfile
+++ b/AgentPortalApiGateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -14,7 +14,7 @@ FROM build AS publish
 WORKDIR $APP_HOME
 RUN cd $APP_HOME && dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:8099
 ENV ASPNETCORE_ENVIRONMENT=docker

--- a/AuthService/AuthService.csproj
+++ b/AuthService/AuthService.csproj
@@ -5,11 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
 </Project>

--- a/AuthService/AuthService.csproj
+++ b/AuthService/AuthService.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3"/>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
 </Project>

--- a/AuthService/Dockerfile
+++ b/AuthService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -14,7 +14,7 @@ FROM build AS publish
 WORKDIR $APP_HOME
 RUN cd $APP_HOME && dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:6060
 COPY --from=publish /opt/app/out ./

--- a/BlazorWasmClient/BlazorWasmClient.csproj
+++ b/BlazorWasmClient/BlazorWasmClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Version>1.3</Version>
@@ -29,8 +29,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Blazorise"					Version="1.3.*" />
-		<PackageReference Include="Blazorise.Bootstrap5"		Version="1.3.*" />
+		<PackageReference Include="Blazorise" Version="1.3.*" />
+		<PackageReference Include="Blazorise.Bootstrap5" Version="1.3.*" />
 		<PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.3.*" />
 	</ItemGroup>
 

--- a/BlazorWasmClient/BlazorWasmClient.csproj
+++ b/BlazorWasmClient/BlazorWasmClient.csproj
@@ -16,22 +16,22 @@
 
 	<ItemGroup>
 		<PackageReference Include="Blazored.SessionStorage" Version="2.4.0" />
-		<PackageReference Include="Blazorise.Charts" Version="1.3.1" />
-		<PackageReference Include="Blazorise.Components" Version="1.3.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.11" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.11" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.11" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.2" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+		<PackageReference Include="Blazorise.Charts" Version="1.5.3" />
+		<PackageReference Include="Blazorise.Components" Version="1.5.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.6" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Blazorise" Version="1.3.*" />
-		<PackageReference Include="Blazorise.Bootstrap5" Version="1.3.*" />
-		<PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.3.*" />
+		<PackageReference Include="Blazorise" Version="1.5.3" />
+		<PackageReference Include="Blazorise.Bootstrap5" Version="1.5.3" />
+		<PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.5.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ChatService.Api/ChatService.Api.csproj
+++ b/ChatService.Api/ChatService.Api.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3"/>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="MediatR" Version="12.0.1" />
     </ItemGroup>
 
 </Project>

--- a/ChatService.Api/ChatService.Api.csproj
+++ b/ChatService.Api/ChatService.Api.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
     </ItemGroup>
 
 </Project>

--- a/ChatService/ChatService.csproj
+++ b/ChatService/ChatService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -10,8 +10,8 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4" />
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="EasyNetQ" Version="7.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ChatService/ChatService.csproj
+++ b/ChatService/ChatService.csproj
@@ -5,13 +5,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
-        <PackageReference Include="EasyNetQ" Version="7.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
+        <PackageReference Include="EasyNetQ" Version="7.8.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ChatService/Dockerfile
+++ b/ChatService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -18,7 +18,7 @@ FROM build AS publish
 WORKDIR $APP_HOME/ChatService
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:4099
 ENV ASPNETCORE_ENVIRONMENT=docker

--- a/DashboardService.Api/DashboardService.Api.csproj
+++ b/DashboardService.Api/DashboardService.Api.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
     </ItemGroup>
 
 </Project>

--- a/DashboardService.Api/DashboardService.Api.csproj
+++ b/DashboardService.Api/DashboardService.Api.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
+        <PackageReference Include="MediatR" Version="12.0.1" />
     </ItemGroup>
 
 </Project>

--- a/DashboardService.Test/DashboardService.Test.csproj
+++ b/DashboardService.Test/DashboardService.Test.csproj
@@ -8,15 +8,18 @@
 
     <ItemGroup>
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.3" />
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Testcontainers.Elasticsearch" Version="3.9.0" />
         <PackageReference Include="xunit" Version="2.8.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/DashboardService.Test/DashboardService.Test.csproj
+++ b/DashboardService.Test/DashboardService.Test.csproj
@@ -10,9 +10,12 @@
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.3" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Testcontainers.Elasticsearch" Version="3.5.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageReference Include="Testcontainers.Elasticsearch" Version="3.9.0" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="coverlet.collector" Version="3.2.0" />
     </ItemGroup>
 

--- a/DashboardService.Test/DashboardService.Test.csproj
+++ b/DashboardService.Test/DashboardService.Test.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.3" />
-        <PackageReference Include="FluentAssertions" Version="5.10.3"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Testcontainers.Elasticsearch" Version="3.5.0" />
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DashboardService.Api\DashboardService.Api.csproj"/>
-        <ProjectReference Include="..\DashboardService\DashboardService.csproj"/>
+        <ProjectReference Include="..\DashboardService.Api\DashboardService.Api.csproj" />
+        <ProjectReference Include="..\DashboardService\DashboardService.csproj" />
     </ItemGroup>
 
 </Project>

--- a/DashboardService/DashboardService.csproj
+++ b/DashboardService/DashboardService.csproj
@@ -5,14 +5,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
-        <PackageReference Include="EasyNetQ" Version="7.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.7" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.7" />
+        <PackageReference Include="EasyNetQ" Version="7.8.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.3" />
     </ItemGroup>
 

--- a/DashboardService/DashboardService.csproj
+++ b/DashboardService/DashboardService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -11,8 +11,8 @@
         <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
         <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
         <PackageReference Include="EasyNetQ" Version="7.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.3" />
     </ItemGroup>
 

--- a/DashboardService/Dockerfile
+++ b/DashboardService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -18,7 +18,7 @@ FROM build AS publish
 WORKDIR $APP_HOME/DashboardService
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:5035
 ENV ASPNETCORE_ENVIRONMENT=docker

--- a/PaymentService.Api/PaymentService.Api.csproj
+++ b/PaymentService.Api/PaymentService.Api.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="11.5.1" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="FluentValidation" Version="11.9.2" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
     </ItemGroup>
 
 </Project>

--- a/PaymentService.Api/PaymentService.Api.csproj
+++ b/PaymentService.Api/PaymentService.Api.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="11.5.1"/>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
+        <PackageReference Include="FluentValidation" Version="11.5.1" />
+        <PackageReference Include="MediatR" Version="12.0.1" />
     </ItemGroup>
 
 </Project>

--- a/PaymentService.Test/PaymentService.Test.csproj
+++ b/PaymentService.Test/PaymentService.Test.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="xunit" Version="2.8.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
           <PrivateAssets>all</PrivateAssets>

--- a/PaymentService.Test/PaymentService.Test.csproj
+++ b/PaymentService.Test/PaymentService.Test.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\PaymentService\PaymentService.csproj"/>
+        <ProjectReference Include="..\PaymentService\PaymentService.csproj" />
     </ItemGroup>
 
 </Project>

--- a/PaymentService.Test/PaymentService.Test.csproj
+++ b/PaymentService.Test/PaymentService.Test.csproj
@@ -7,8 +7,11 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/PaymentService/Dockerfile
+++ b/PaymentService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -28,7 +28,7 @@ FROM build AS publish
 WORKDIR $APP_HOME/PaymentService
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:5070
 ENV ASPNETCORE_ENVIRONMENT=docker

--- a/PaymentService/PaymentService.csproj
+++ b/PaymentService/PaymentService.csproj
@@ -8,18 +8,18 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Hangfire.AspNetCore" Version="1.7.33" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
-        <PackageReference Include="Dapper" Version="2.0.123" />
+        <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
+        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="GlobalExceptionHandler" Version="4.0.2" />
-        <PackageReference Include="Hangfire.PostgreSql" Version="1.19.12" />
+        <PackageReference Include="Hangfire.PostgreSql" Version="1.20.8" />
         <PackageReference Include="Hangfire.PostgreSql.NetCore" Version="1.4.3" />
-        <PackageReference Include="Marten" Version="5.11.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
-        <PackageReference Include="EasyNetQ" Version="7.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Marten" Version="7.19.1" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+        <PackageReference Include="EasyNetQ" Version="7.8.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PaymentService/PaymentService.csproj
+++ b/PaymentService/PaymentService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DockerComposeProjectPath>..\..\docker-compose.dcproj</DockerComposeProjectPath>
         <UserSecretsId>6e9f2776-8954-46fe-b74a-372f9006db7b</UserSecretsId>
     </PropertyGroup>
@@ -18,8 +18,8 @@
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
         <PackageReference Include="EasyNetQ" Version="7.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PolicySearchService.Api/PolicySearchService.Api.csproj
+++ b/PolicySearchService.Api/PolicySearchService.Api.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
     </ItemGroup>
 
 </Project>

--- a/PolicySearchService.Api/PolicySearchService.Api.csproj
+++ b/PolicySearchService.Api/PolicySearchService.Api.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
+        <PackageReference Include="MediatR" Version="12.0.1" />
     </ItemGroup>
 
 </Project>

--- a/PolicySearchService/Dockerfile
+++ b/PolicySearchService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -18,7 +18,7 @@ FROM build AS publish
 WORKDIR $APP_HOME/PolicySearchService
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:5065
 ENV ASPNETCORE_ENVIRONMENT=docker

--- a/PolicySearchService/PolicySearchService.csproj
+++ b/PolicySearchService/PolicySearchService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/PolicySearchService/PolicySearchService.csproj
+++ b/PolicySearchService/PolicySearchService.csproj
@@ -5,15 +5,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="EasyNetQ" Version="7.5.0" />
+        <PackageReference Include="EasyNetQ" Version="7.8.0" />
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
         <PackageReference Include="GlobalExceptionHandler" Version="4.0.2" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
-        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
+        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.7" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.7" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PolicyService.Api/PolicyService.Api.csproj
+++ b/PolicyService.Api/PolicyService.Api.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PolicyService.Api/PolicyService.Api.csproj
+++ b/PolicyService.Api/PolicyService.Api.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/PolicyService.Test/PolicyService.Test.csproj
+++ b/PolicyService.Test/PolicyService.Test.csproj
@@ -8,8 +8,11 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/PolicyService.Test/PolicyService.Test.csproj
+++ b/PolicyService.Test/PolicyService.Test.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="xunit" Version="2.8.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
           <PrivateAssets>all</PrivateAssets>

--- a/PolicyService.Test/PolicyService.Test.csproj
+++ b/PolicyService.Test/PolicyService.Test.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\PolicyService.Api\PolicyService.Api.csproj"/>
-        <ProjectReference Include="..\PolicyService\PolicyService.csproj"/>
+        <ProjectReference Include="..\PolicyService.Api\PolicyService.Api.csproj" />
+        <ProjectReference Include="..\PolicyService\PolicyService.csproj" />
     </ItemGroup>
 
 </Project>

--- a/PolicyService/Dockerfile
+++ b/PolicyService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -28,7 +28,7 @@ FROM build AS publish
 WORKDIR $APP_HOME/PolicyService
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:5050
 ENV ASPNETCORE_ENVIRONMENT=docker

--- a/PolicyService/PolicyService.csproj
+++ b/PolicyService/PolicyService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <UserSecretsId>0a1d70d5-102b-4bdc-9526-438b3daef0b5</UserSecretsId>
     </PropertyGroup>
 
@@ -29,8 +29,8 @@
         <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
         <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
         <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PolicyService/PolicyService.csproj
+++ b/PolicyService/PolicyService.csproj
@@ -19,18 +19,18 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="EasyNetQ" Version="7.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
-        <PackageReference Include="NHibernate" Version="5.4.1" />
-        <PackageReference Include="Npgsql" Version="7.0.2" />
-        <PackageReference Include="Polly" Version="7.2.1" />
-        <PackageReference Include="RestEase" Version="1.6.1" />
+        <PackageReference Include="EasyNetQ" Version="7.8.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
+        <PackageReference Include="NHibernate" Version="5.5.1" />
+        <PackageReference Include="Npgsql" Version="8.0.3" />
+        <PackageReference Include="Polly" Version="8.4.0" />
+        <PackageReference Include="RestEase" Version="1.6.4" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
         <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
-        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.7" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.7" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PolicyService/Program.cs
+++ b/PolicyService/Program.cs
@@ -7,7 +7,7 @@ using Serilog.Events;
 
 namespace PolicyService;
 
-public class Program
+public static class Program
 {
     public static void Main(string[] args)
     {

--- a/PricingService.Api/PricingService.Api.csproj
+++ b/PricingService.Api/PricingService.Api.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="11.5.1" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="FluentValidation" Version="11.9.2" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/PricingService.Api/PricingService.Api.csproj
+++ b/PricingService.Api/PricingService.Api.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="11.5.1"/>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageReference Include="FluentValidation" Version="11.5.1" />
+        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PricingService.IntegrationTest/PricingControllerTest.cs
+++ b/PricingService.IntegrationTest/PricingControllerTest.cs
@@ -44,14 +44,14 @@ public class PricingControllerTest
             _.StatusCodeShouldBeOk();
         });
 
-        var calculationResult = response.ReadAsJson<CalculatePriceResult>();
+        var calculationResult = await response.ReadAsJsonAsync<CalculatePriceResult>();
         Equal(98M, calculationResult.TotalPrice);
     }
 
     [Fact]
     public async Task CommandIsProperlyValidated()
     {
-        var response = await fixture.SystemUnderTest.Scenario(_ =>
+        _ = await fixture.SystemUnderTest.Scenario(_ =>
         {
             _.Post
                 .Json(new CalculatePriceCommand())

--- a/PricingService.IntegrationTest/PricingService.IntegrationTest.csproj
+++ b/PricingService.IntegrationTest/PricingService.IntegrationTest.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.3.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="Testcontainers" Version="3.0.0"/>
-        <PackageReference Include="Testcontainers.PostgreSql" Version="3.0.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2"/>
+        <PackageReference Include="Alba" Version="7.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Testcontainers" Version="3.0.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="3.0.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     </ItemGroup>
 
 
     <ItemGroup>
-        <ProjectReference Include="..\PricingService\PricingService.csproj"/>
+        <ProjectReference Include="..\PricingService\PricingService.csproj" />
     </ItemGroup>
 
 </Project>

--- a/PricingService.IntegrationTest/PricingService.IntegrationTest.csproj
+++ b/PricingService.IntegrationTest/PricingService.IntegrationTest.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Alba" Version="7.4.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Testcontainers" Version="3.9.0" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="3.9.0" />
         <PackageReference Include="xunit" Version="2.8.1" />

--- a/PricingService.IntegrationTest/PricingService.IntegrationTest.csproj
+++ b/PricingService.IntegrationTest/PricingService.IntegrationTest.csproj
@@ -10,10 +10,13 @@
         <PackageReference Include="Alba" Version="7.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Testcontainers" Version="3.0.0" />
-        <PackageReference Include="Testcontainers.PostgreSql" Version="3.0.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+        <PackageReference Include="Testcontainers" Version="3.9.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="3.9.0" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
 

--- a/PricingService.Test/Commands/CalculatePriceHandlerShould.cs
+++ b/PricingService.Test/Commands/CalculatePriceHandlerShould.cs
@@ -26,7 +26,7 @@ public class CalculatePriceHandlerShould
             await Assert.ThrowsAsync<ValidationException>(() => handler.Handle(command, CancellationToken.None));
 
         Assert.NotNull(exception);
-        Assert.True(exception.Errors.Count() > 0);
+        Assert.True(exception.Errors.Any());
     }
 
     [Fact]

--- a/PricingService.Test/PricingService.Test.csproj
+++ b/PricingService.Test/PricingService.Test.csproj
@@ -10,8 +10,11 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/PricingService.Test/PricingService.Test.csproj
+++ b/PricingService.Test/PricingService.Test.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="Moq" Version="4.18.4"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\PricingService\PricingService.csproj"/>
+        <ProjectReference Include="..\PricingService\PricingService.csproj" />
     </ItemGroup>
 
 </Project>

--- a/PricingService.Test/PricingService.Test.csproj
+++ b/PricingService.Test/PricingService.Test.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.8.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
           <PrivateAssets>all</PrivateAssets>

--- a/PricingService/Commands/CalculatePriceHandler.cs
+++ b/PricingService/Commands/CalculatePriceHandler.cs
@@ -20,7 +20,7 @@ public class CalculatePriceHandler : IRequestHandler<CalculatePriceCommand, Calc
 
     public async Task<CalculatePriceResult> Handle(CalculatePriceCommand cmd, CancellationToken cancellationToken)
     {
-        commandValidator.ValidateAndThrow(cmd);
+        await commandValidator.ValidateAndThrowAsync(cmd);
 
         var tariff = await dataStore.Tariffs[cmd.ProductCode];
 

--- a/PricingService/Dockerfile
+++ b/PricingService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -26,7 +26,7 @@ FROM build AS publish
 WORKDIR $APP_HOME/PricingService
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:5040
 ENV ASPNETCORE_ENVIRONMENT=docker

--- a/PricingService/PricingService.csproj
+++ b/PricingService/PricingService.csproj
@@ -6,17 +6,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
-        <PackageReference Include="DynamicExpresso.Core" Version="2.13.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
+        <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
         <PackageReference Include="GlobalExceptionHandler" Version="4.0.2" />
-        <PackageReference Include="Marten" Version="5.11.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="Marten" Version="7.19.1" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
         <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
-        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.7" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.7" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PricingService/PricingService.csproj
+++ b/PricingService/PricingService.csproj
@@ -1,30 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <UserSecretsId>db17c895-b36a-4a46-adb9-0f14c003764d</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3"/>
-        <PackageReference Include="DynamicExpresso.Core" Version="2.13.0"/>
-        <PackageReference Include="GlobalExceptionHandler" Version="4.0.2"/>
-        <PackageReference Include="Marten" Version="5.11.0"/>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
-        <PackageReference Include="Serilog.AspNetCore" Version="6.1.0"/>
-        <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1"/>
-        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3"/>
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="DynamicExpresso.Core" Version="2.13.0" />
+        <PackageReference Include="GlobalExceptionHandler" Version="4.0.2" />
+        <PackageReference Include="Marten" Version="5.11.0" />
+        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+        <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\PricingService.Api\PricingService.Api.csproj"/>
+        <ProjectReference Include="..\PricingService.Api\PricingService.Api.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties"/>
+        <Folder Include="Properties" />
     </ItemGroup>
 
 </Project>

--- a/ProductService.Api/ProductService.Api.csproj
+++ b/ProductService.Api/ProductService.Api.csproj
@@ -6,7 +6,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/ProductService.Api/ProductService.Api.csproj
+++ b/ProductService.Api/ProductService.Api.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>

--- a/ProductService.Test/ProductService.Test.csproj
+++ b/ProductService.Test/ProductService.Test.csproj
@@ -16,8 +16,11 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/ProductService.Test/ProductService.Test.csproj
+++ b/ProductService.Test/ProductService.Test.csproj
@@ -1,28 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Remove="DataAccess\**"/>
-        <EmbeddedResource Remove="DataAccess\**"/>
-        <None Remove="DataAccess\**"/>
+        <Compile Remove="DataAccess\**" />
+        <EmbeddedResource Remove="DataAccess\**" />
+        <None Remove="DataAccess\**" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="Moq" Version="4.18.4"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ProductService.Api\ProductService.Api.csproj"/>
-        <ProjectReference Include="..\ProductService\ProductService.csproj"/>
+        <ProjectReference Include="..\ProductService.Api\ProductService.Api.csproj" />
+        <ProjectReference Include="..\ProductService\ProductService.csproj" />
     </ItemGroup>
 
 </Project>

--- a/ProductService.Test/ProductService.Test.csproj
+++ b/ProductService.Test/ProductService.Test.csproj
@@ -13,9 +13,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.8.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
           <PrivateAssets>all</PrivateAssets>

--- a/ProductService/Dockerfile
+++ b/ProductService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ENV APP_HOME /opt/app
 RUN mkdir $APP_HOME
@@ -27,7 +27,7 @@ FROM build AS publish
 WORKDIR $APP_HOME/ProductService
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:5030
 ENV ASPNETCORE_ENVIRONMENT=docker

--- a/ProductService/ProductService.csproj
+++ b/ProductService/ProductService.csproj
@@ -1,37 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DockerComposeProjectPath>..\..\docker-compose.dcproj</DockerComposeProjectPath>
         <UserSecretsId>05bcfaf7-30a8-4ab0-bc4f-517e6f836df5</UserSecretsId>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Remove="wwwroot\**"/>
-        <Content Remove="wwwroot\**"/>
-        <EmbeddedResource Remove="wwwroot\**"/>
-        <None Remove="wwwroot\**"/>
+        <Compile Remove="wwwroot\**" />
+        <Content Remove="wwwroot\**" />
+        <EmbeddedResource Remove="wwwroot\**" />
+        <None Remove="wwwroot\**" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Ensure.That" Version="10.1.0"/>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3"/>
+        <PackageReference Include="Ensure.That" Version="10.1.0" />
+        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
 
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.3"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
 
-        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3"/>
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3"/>
+        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
 
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ProductService.Api\ProductService.Api.csproj"/>
+        <ProjectReference Include="..\ProductService.Api\ProductService.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/ProductService/ProductService.csproj
+++ b/ProductService/ProductService.csproj
@@ -16,18 +16,18 @@
 
     <ItemGroup>
         <PackageReference Include="Ensure.That" Version="10.1.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="MediatR" Version="12.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
 
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
 
-        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.3" />
-        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.3" />
+        <PackageReference Include="Steeltoe.Discovery.ClientBase" Version="3.2.7" />
+        <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.7" />
 
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is an example of a very simplified insurance sales system made in a microservice architecture using:
 
-- .NET 8 (Migration in progress)
+- .NET 8
 - Entity Framework Core
 - MediatR
 - Marten

--- a/README.md
+++ b/README.md
@@ -4,37 +4,37 @@
 
 This is an example of a very simplified insurance sales system made in a microservice architecture using:
 
-* .NET 7
-* Entity Framework Core
-* MediatR
-* Marten
-* Eureka
-* Ocelot
-* JWT Tokens
-* RestEase
-* RawRabbit
-* NHibernate
-* Polly
-* NEST (ElasticSearch client)
-* Dapper
-* DynamicExpresso
-* SignalR
+- .NET 7 / .NET 8 (Migration in progress)
+- Entity Framework Core
+- MediatR
+- Marten
+- Eureka
+- Ocelot
+- JWT Tokens
+- RestEase
+- RawRabbit
+- NHibernate
+- Polly
+- NEST (ElasticSearch client)
+- Dapper
+- DynamicExpresso
+- SignalR
 
 **Comprehensive guide describing the architecture, applied design patterns and technologies can be found on our blog:**
 
-* [Part 1 The Plan](https://www.altkomsoftware.com/blog/building-microservices-net-core-part-1-plan/)
-* [Part 2 Shaping microservice internal architecture with CQRS and MediatR](https://www.altkomsoftware.com/blog/microservices-net-core-cqrs-mediatr/)
-* [Part 3 Service Discovery with Eureka](https://www.altkomsoftware.com/blog/microservices-service-discovery-eureka/)
-* [Part 4 Building API Gateways With Ocelot](https://www.altkomsoftware.com/blog/building-api-gateways-with-ocelot/)
-* [Part 5 Marten An Ideal Repository For Your Domain Aggregates](https://www.altkomsoftware.com/blog/building-microservices-net-core-part-5-marten-ideal-repository-domain-aggregates/)
-* [Part 6 Real time server client communication with SignalR and RabbitMQ](https://www.altkomsoftware.com/blog/building-microservices-6/)
-* [Part 7 Transactional Outbox with RabbitMQ](https://www.altkomsoftware.com/blog/microservices-outbox-rabbitmq/)
+- [Part 1 The Plan](https://www.altkomsoftware.com/blog/building-microservices-net-core-part-1-plan/)
+- [Part 2 Shaping microservice internal architecture with CQRS and MediatR](https://www.altkomsoftware.com/blog/microservices-net-core-cqrs-mediatr/)
+- [Part 3 Service Discovery with Eureka](https://www.altkomsoftware.com/blog/microservices-service-discovery-eureka/)
+- [Part 4 Building API Gateways With Ocelot](https://www.altkomsoftware.com/blog/building-api-gateways-with-ocelot/)
+- [Part 5 Marten An Ideal Repository For Your Domain Aggregates](https://www.altkomsoftware.com/blog/building-microservices-net-core-part-5-marten-ideal-repository-domain-aggregates/)
+- [Part 6 Real time server client communication with SignalR and RabbitMQ](https://www.altkomsoftware.com/blog/building-microservices-6/)
+- [Part 7 Transactional Outbox with RabbitMQ](https://www.altkomsoftware.com/blog/microservices-outbox-rabbitmq/)
 
 Other articles around microservices that could be interesting:
 
-* [CQRS and Event Sourcing Intro For Developers](https://www.altkomsoftware.com/blog/cqrs-event-sourcing/)
-* [From monolith to microservices – to migrate or not to migrate?](https://www.altkomsoftware.com/blog/monolith-microservices/)
-* [Event Storming — innovation in IT projects](https://www.altkomsoftware.com/blog/event-storming/)
+- [CQRS and Event Sourcing Intro For Developers](https://www.altkomsoftware.com/blog/cqrs-event-sourcing/)
+- [From monolith to microservices – to migrate or not to migrate?](https://www.altkomsoftware.com/blog/monolith-microservices/)
+- [Event Storming — innovation in IT projects](https://www.altkomsoftware.com/blog/event-storming/)
 
 ## Business Case
 
@@ -51,33 +51,33 @@ Latest feature is a business dashboard that displays sales stats using ElasticSe
     <img alt="NET Microservices Architecture" src="https://raw.githubusercontent.com/asc-lab/dotnetcore-microservices-poc/master/readme-images/dotnetcore-microservices-architecture.png" />
 </p>
 
-* **Web** - a VueJS Single Page Application that provides insurance agents ability to select appropriate product for their customers, calculate price, create an offer and conclude the sales process by converting offer to policy. This application also provides search and view functions for policies and offers. Frontend talks to backend services via `agent-portal-gateway`.
+- **Web** - a VueJS Single Page Application that provides insurance agents ability to select appropriate product for their customers, calculate price, create an offer and conclude the sales process by converting offer to policy. This application also provides search and view functions for policies and offers. Frontend talks to backend services via `agent-portal-gateway`.
 
-* **Agent Portal API Gateway** - is a special microservice whose main purpose it to hide complexity of the underlying back office services structure from client application. Usually we create a dedicated API gateway for each client app. In case in the future we add a Xamarin mobile app to our system, we will need to build a dedicated API gateway for it. API gateway provides also security barrier and does not allow unauthenticated request to be passed to backend services. Another popular usage of API gateways is content aggregation from multiple services.
+- **Agent Portal API Gateway** - is a special microservice whose main purpose it to hide complexity of the underlying back office services structure from client application. Usually we create a dedicated API gateway for each client app. In case in the future we add a Xamarin mobile app to our system, we will need to build a dedicated API gateway for it. API gateway provides also security barrier and does not allow unauthenticated request to be passed to backend services. Another popular usage of API gateways is content aggregation from multiple services.
 
-* **Auth Service** - a service responsible for users authentication. Our security system will be based on JWT tokens. Once user identifies himself correctly, auth service issues a token that is further use to check user permission and available products.
+- **Auth Service** - a service responsible for users authentication. Our security system will be based on JWT tokens. Once user identifies himself correctly, auth service issues a token that is further use to check user permission and available products.
 
-* **Chat Service** - a service that uses SignalR to give agents ability to chat with each other.
+- **Chat Service** - a service that uses SignalR to give agents ability to chat with each other.
 
-* **Payment Service** - main responsibilities: create Policy Account, show Policy Account list, register in payments from bank statement file. \
-This module is taking care of a managing policy accounts. Once the policy is created, an account is created in this service with expected money income.  PaymentService also has an implementation of a scheduled process where CSV file with payments is imported and payments are assigned to policy accounts. This component shows asynchronous communication between services using RabbitMQ and ability to create background jobs. It also features accessing database using Dapper.
+- **Payment Service** - main responsibilities: create Policy Account, show Policy Account list, register in payments from bank statement file. \
+  This module is taking care of a managing policy accounts. Once the policy is created, an account is created in this service with expected money income. PaymentService also has an implementation of a scheduled process where CSV file with payments is imported and payments are assigned to policy accounts. This component shows asynchronous communication between services using RabbitMQ and ability to create background jobs. It also features accessing database using Dapper.
 
-* **Policy Service** - creates offers, converts offers to insurance policies. \
-In this service we demonstrated usage of CQRS pattern for better read/write operation isolation. This service demonstrates two ways of communication between services: synchronous REST based calls to `PricingService` through HTTP Client to get the price, and asynchronous event based using RabbitMQ to publish information about newly created policies. In this service we also access RDBMS using NHibernate.
+- **Policy Service** - creates offers, converts offers to insurance policies. \
+  In this service we demonstrated usage of CQRS pattern for better read/write operation isolation. This service demonstrates two ways of communication between services: synchronous REST based calls to `PricingService` through HTTP Client to get the price, and asynchronous event based using RabbitMQ to publish information about newly created policies. In this service we also access RDBMS using NHibernate.
 
-* **Policy Search Service** - provides insurance policy search. \
-This module listens for events from RabbitMQ, converts received DTOs to “read model” and indexes given model in ElasticSearch to provide advanced search capabilities.
+- **Policy Search Service** - provides insurance policy search. \
+  This module listens for events from RabbitMQ, converts received DTOs to “read model” and indexes given model in ElasticSearch to provide advanced search capabilities.
 
-* **Pricing Service** - a service responsible for calculation of price for given insurance product based on its parametrization. \
-For each product a tariff should be defined. The tariff is a set of rules on the basis of which the price is calculated. DynamicExpresso was used to parse the rules. During the policy purchase process, the `PolicyService` connects with this service to calculate a price. Price is calculated based on user’s answers for defined questions.
+- **Pricing Service** - a service responsible for calculation of price for given insurance product based on its parametrization. \
+  For each product a tariff should be defined. The tariff is a set of rules on the basis of which the price is calculated. DynamicExpresso was used to parse the rules. During the policy purchase process, the `PolicyService` connects with this service to calculate a price. Price is calculated based on user’s answers for defined questions.
 
-* **Product Service** - simple insurance product catalog. \
-It provides basic information about each insurance product and its parameters that can be customized while creating an offer for a customer.
+- **Product Service** - simple insurance product catalog. \
+  It provides basic information about each insurance product and its parameters that can be customized while creating an offer for a customer.
 
-* **Document Service** - this service uses JS Report to generate pdf certificates.
+- **Document Service** - this service uses JS Report to generate pdf certificates.
 
-* **Dashboard Service** - Dashboard that presents sales statistics. \
-Business dashboards that presents our agents sales results. Dashboard service subscribes to events of selling policies and index sales data in ElasticSearch. Then ElasticSearch aggregation framework is used to calculate sales stats like: total sales and number of policies per product per time period, sales per agent in given time period and sales timeline. Sales stats are nicely visualized using ChartJS.
+- **Dashboard Service** - Dashboard that presents sales statistics. \
+  Business dashboards that presents our agents sales results. Dashboard service subscribes to events of selling policies and index sales data in ElasticSearch. Then ElasticSearch aggregation framework is used to calculate sales stats like: total sales and number of policies per product per time period, sales per agent in given time period and sales timeline. Sales stats are nicely visualized using ChartJS.
 
 Each business microservice has also **.Api project** (`PaymentService.Api`, `PolicyService.Api` etc.), where we defined commands, events, queries and operations and **.Test project** (`PaymentService.Test`, `PolicyService.Test`) with unit and integration tests.
 
@@ -86,19 +86,20 @@ Each business microservice has also **.Api project** (`PaymentService.Api`, `Pol
 You must install Docker & Docker Compose before. \
 Scripts have been divided into two parts:
 
-* [`infra.yml`](scripts/infra.yml) runs the necessary infrastructure.
-* [`app.yml`](scripts/app.yml) is used to run the application.
+- [`infra.yml`](scripts/infra.yml) runs the necessary infrastructure.
+- [`app.yml`](scripts/app.yml) is used to run the application.
 
 You can use scripts to build/run/stop/down all containers.
 
 To run the whole solution:
 
 ```bash
+cd scripts
 ./infra-run.sh
 ./app-run.sh
 ```
 
->If ElasticSearch fails to start, try running `sudo sysctl -w vm.max_map_count=262144` first
+> If ElasticSearch fails to start, try running `sudo sysctl -w vm.max_map_count=262144` first
 
 Once the application and infrastructure are started you can open http://localhost:8080 in your browser and see our welcome page.
 Once there you can use Account menu item to log into the system. Valid users and passwords can be found [here](https://github.com/asc-lab/dotnetcore-microservices-poc/blob/master/AuthService/DataAccess/InsuranceAgentsInMemoryDb.cs). You can for example login as admin with password admin.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is an example of a very simplified insurance sales system made in a microservice architecture using:
 
-- .NET 7 / .NET 8 (Migration in progress)
+- .NET 8 (Migration in progress)
 - Entity Framework Core
 - MediatR
 - Marten

--- a/scripts/infra.yml
+++ b/scripts/infra.yml
@@ -16,21 +16,23 @@ services:
       - /tmp/data/postgresql:/var/lib/postgresql/data
     ports:
       - 5432:5432
+    environment:
+      - POSTGRES_PASSWORD=lab_pass
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.9.2
     container_name: elasticsearch
     environment:
-    - discovery.type=single-node
-    - bootstrap.memory_lock=true
-    - xpack.security.enabled=false
-    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=false
+      - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
     ulimits:
       memlock:
         soft: -1
         hard: -1
     ports:
-    - 9200:9200
+      - 9200:9200
 
   rabbitmq:
     image: rabbitmq:3-management


### PR DESCRIPTION
## What does this PR ?

- Migrating all projects from .NET 7 to .NET 8
- Updating all packages to latest versions, except:
  - `Elastic.Clients.Elasticsearch`
  - `Serilog.AspNetCore`
- Got rid some simple warning
- `/scripts/infra.yml` was getting an error by default. It was fixed adding the environment variable `POSTGRES_PASSWORD`
- README: Adding `cd scripts` step in the section `To run the whole solution`

## Considerations

### Some unit and integrated tests are failing even before the changes:

- `PricingService.IntegrationTest.PricingControllerTest.PriceForTravelPolicyIsCorrect`
- `DashboardService.Test.GetSalesTrendsQueryTest.SalesTrends_All_Product_In_First_Q_2020`
- `DashboardService.Test.GetSalesTrendsQueryTest.SalesTrends_HSI_Product_In_First_Q_2020`

### Running through scripts (containers)

When running `scripts/infra-run.sh` + `scripts/app-run.sh` the container `dotnet-policy-service` is failing even without this PR's changes with the following error (`relation "outbox_messages" does not exist`):

```
Unhandled exception. System.AggregateException: One or more errors occurred. (could not execute query
2024-06-19 07:46:24 [ select message0_.id as id1_0_, message0_.type as type2_0_, message0_.json_payload as json3_0_ from outbox_messages message0_ order by message0_.id asc limit :p0 ]
2024-06-19 07:46:24   Name:p1 - Value:50 [Type: NHibernate.Type.Int32Type (SqlType: Int32)]
```